### PR TITLE
Updating API base URL

### DIFF
--- a/printful.py
+++ b/printful.py
@@ -47,7 +47,7 @@ class Printful:
 
         """
         self.key = bytearray(key, 'utf-8')
-        self.api_url = 'https://api.theprintful.com/'
+        self.api_url = 'https://api.printful.com/'
         self.user_agent = 'Printful API Python Library 1.2'
         self._response = {}
 


### PR DESCRIPTION
Former API URL (api.theprintful.com) has now been deprecated, see response from Printful: 

Printful: Yes, it has been depreciated. API requests should be sent to api.printful.com. Let us know if you have any other questions. All the best!

